### PR TITLE
fix: correct README repo and path references

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ The repository is organized into several chapters, each focusing on different as
 
 1. **Clone the repository to your local machine:**
     ```bash
-    git clone https://github.com/k0wl0n/kubernetes-course-manifest.git
+    git clone https://github.com/k0wl0n/kubernetes-course-materials.git
     ```
 
 2. **Navigate to the desired chapter and sub-chapter to explore the examples and manifests:**
     ```bash
-    cd kubernetes-manifest/P2-Ch.04/P2-Ch.04-2-5.Pods
+    cd kubernetes-course-materials/P2-Ch.04/P2-Ch.04-2-5.Pods
     ```
 
 3. **Apply the Kubernetes manifests using `kubectl`:**


### PR DESCRIPTION
## Summary
- fix repository URL in clone instructions
- align directory path example with actual repo structure

## Testing
- `npm test` *(fails: Could not read package.json)*
- `make test` *(fails: No rule to make target `test`)*

------
https://chatgpt.com/codex/tasks/task_e_689eaafcb294832cb87ba484c6b592f6